### PR TITLE
Adds support to allow duplicate generic argument detection

### DIFF
--- a/TypeSupport/TypeSupport.Tests/TypeSupportTests.cs
+++ b/TypeSupport/TypeSupport.Tests/TypeSupportTests.cs
@@ -198,6 +198,19 @@ namespace TypeSupport.Tests
         }
 
         [Test]
+        public void Should_Discover_GenericDictionaryDuplicateTypes()
+        {
+            var type = typeof(IDictionary<int, int>);
+            var typeSupport = new ExtendedType(type);
+
+            Assert.NotNull(typeSupport);
+            Assert.AreEqual(true, typeSupport.IsDictionary);
+            Assert.AreEqual(2, typeSupport.GenericArgumentTypes.Count);
+            Assert.AreEqual(typeof(int), typeSupport.GenericArgumentTypes.First());
+            Assert.AreEqual(typeof(int), typeSupport.GenericArgumentTypes.Skip(1).First());
+        }
+
+        [Test]
         public void Should_Discover_Dictionary()
         {
             var type = typeof(IDictionary);

--- a/TypeSupport/TypeSupport/ExtendedType.cs
+++ b/TypeSupport/TypeSupport/ExtendedType.cs
@@ -529,8 +529,7 @@ namespace TypeSupport
             {
                 foreach (var arg in args)
                 {
-                    if (!GenericArgumentTypes.Contains(arg))
-                        GenericArgumentTypes.Add(arg);
+                    GenericArgumentTypes.Add(arg);
                 }
             }
 


### PR DESCRIPTION
Duplicate generic arguments should be allowed, such as in Dictionaries with the same key/value type