### PR TITLE
Fixes #11 - recursive overload is calling itself in CreateEmptyObject

### DIFF
--- a/TypeSupport/TypeSupport.Tests/ObjectFactoryTests.cs
+++ b/TypeSupport/TypeSupport.Tests/ObjectFactoryTests.cs
@@ -175,10 +175,40 @@ namespace TypeSupport.Tests
 #endif
 
         [Test]
-        public void Should_CreateTuple()
+        public void Should_CreateGenericSingularTuple()
+        {
+            var factory = new ObjectFactory();
+            var instance = factory.CreateEmptyObject<Tuple<int>>();
+
+            Assert.NotNull(instance);
+            Assert.AreEqual(typeof(Tuple<int>), instance.GetType());
+        }
+
+        [Test]
+        public void Should_CreateSingularTuple()
+        {
+            var factory = new ObjectFactory();
+            var instance = factory.CreateEmptyObject(typeof(Tuple<int>));
+
+            Assert.NotNull(instance);
+            Assert.AreEqual(typeof(Tuple<int>), instance.GetType());
+        }
+
+        [Test]
+        public void Should_CreateGenericTuple()
         {
             var factory = new ObjectFactory();
             var instance = factory.CreateEmptyObject<Tuple<int, string>>();
+
+            Assert.NotNull(instance);
+            Assert.AreEqual(typeof(Tuple<int, string>), instance.GetType());
+        }
+
+        [Test]
+        public void Should_CreateNonGenericTuple()
+        {
+            var factory = new ObjectFactory();
+            var instance = factory.CreateEmptyObject(typeof(Tuple<int, string>));
 
             Assert.NotNull(instance);
             Assert.AreEqual(typeof(Tuple<int, string>), instance.GetType());

--- a/TypeSupport/TypeSupport/ObjectFactory.cs
+++ b/TypeSupport/TypeSupport/ObjectFactory.cs
@@ -48,17 +48,6 @@ namespace TypeSupport
         /// <summary>
         /// Create a new, empty object of a given type
         /// </summary>
-        /// <param name="type">The type of object to construct</param>
-        /// <param name="typeRegistry">A type registry for constructing unknown types</param>
-        /// <returns></returns>
-        public object CreateEmptyObject(Type type, TypeRegistry typeRegistry)
-        {
-            return CreateEmptyObject(type, typeRegistry);
-        }
-
-        /// <summary>
-        /// Create a new, empty object of a given type
-        /// </summary>
         /// <param name="assemblyQualifiedFullName">The full name of the type to create, <see cref="Type.AssemblyQualifiedName"/></param>
         /// <returns></returns>
         public object CreateEmptyObject(string assemblyQualifiedFullName)


### PR DESCRIPTION
Fixes #11 - recursive overload is calling itself in CreateEmptyObject