### PR TITLE
In a Blazor app the _propertyInfo.GetGetMethod(true) can return null

### DIFF
--- a/TypeSupport/TypeSupport/ExtendedProperty.cs
+++ b/TypeSupport/TypeSupport/ExtendedProperty.cs
@@ -90,7 +90,9 @@ namespace TypeSupport
         public ExtendedProperty(PropertyInfo propertyInfo)
         {
             _propertyInfo = propertyInfo;
-            if (_propertyInfo.GetGetMethod(true)
+
+            if (HasGetMethod 
+                && GetMethod
                     .GetCustomAttributes(typeof(CompilerGeneratedAttribute), true)
                     .Any()
                 && _propertyInfo.DeclaringType


### PR DESCRIPTION
given propertyInfo is set first thing in the constructor it is cleaner to reuse your HasMethod and GetMethod properties than to duplicate them.

This took me a couple of days to find. This only occurs when running in client-side blazor/mono. I filed an issue in AnyClone but turns out the fix is here in TypeSupport.

All tests still pass and the AnyClone Tests pass in my Blazor-State Test suite.

Thanks much for these libs.

