### PR TITLE
Fixes #17 - AmbiguousMatchException thrown

### DIFF
--- a/TypeSupport/TypeSupport.Tests/TestObjects/InheritedObject.cs
+++ b/TypeSupport/TypeSupport.Tests/TestObjects/InheritedObject.cs
@@ -4,12 +4,13 @@ namespace TypeSupport.Tests.TestObjects
     public class InheritedObject : BaseInheritedObject
     {
         private readonly string _name;
-        public int Id { get; set; }
+        public new int Id { get; }
     }
 
     public class BaseInheritedObject
     {
         private readonly string _baseName;
         public int BaseId { get; set; }
+        public int? Id { get; set; }
     }
 }

--- a/TypeSupport/TypeSupport.Tests/TypeSupportTests.cs
+++ b/TypeSupport/TypeSupport.Tests/TypeSupportTests.cs
@@ -357,7 +357,33 @@ namespace TypeSupport.Tests
             var type = typeof(InheritedObject);
             var fields = type.GetFields(FieldOptions.All);
 
-            Assert.AreEqual(4, fields.Count);
+            // there are 4 fields, plus an overridden field with duplicate name
+            Assert.AreEqual(5, fields.Count);
+        }
+
+        [Test]
+        public void Should_Throw_DuplicateInheritedPropertyNames()
+        {
+            var obj = new InheritedObject();
+            Assert.Throws<System.Reflection.AmbiguousMatchException>(() => {
+                var property = obj.GetProperty("Id");
+            });
+        }
+
+        [Test]
+        public void Should_Locate_DuplicateInheritedPropertyNamesByPropertyType()
+        {
+            var obj = new InheritedObject();
+            var property = obj.GetProperty("Id", typeof(int?));
+            Assert.AreEqual(typeof(int?), property.PropertyType);
+        }
+
+        [Test]
+        public void Should_Locate_DuplicateInheritedPropertyNamesByClassOwner()
+        {
+            var obj = new InheritedObject();
+            var property = obj.GetProperty("Id", typeof(BaseInheritedObject));
+            Assert.AreEqual(typeof(int?), property.PropertyType);
         }
 
         [Test]
@@ -366,7 +392,7 @@ namespace TypeSupport.Tests
             var type = typeof(InheritedObject);
             var properties = type.GetProperties(PropertyOptions.All);
 
-            Assert.AreEqual(2, properties.Count);
+            Assert.AreEqual(3, properties.Count);
         }
 
         [Test]

--- a/TypeSupport/TypeSupport/ExtendedField.cs
+++ b/TypeSupport/TypeSupport/ExtendedField.cs
@@ -73,7 +73,7 @@ namespace TypeSupport
                 var i = fieldInfo.Name.IndexOf("<");
                 var end = fieldInfo.Name.IndexOf(">", i + 1);
                 BackedPropertyName = fieldInfo.Name.Substring(i + 1, end - (i + 1));
-                BackedProperty = ReflectedType.GetExtendedProperty(BackedPropertyName);
+                BackedProperty = ReflectedType.GetExtendedProperty(BackedPropertyName, fieldInfo.DeclaringType);
             }
         }
 

--- a/TypeSupport/TypeSupport/Extensions/ObjectExtensions.cs
+++ b/TypeSupport/TypeSupport/Extensions/ObjectExtensions.cs
@@ -44,6 +44,27 @@ namespace TypeSupport.Extensions
         }
 
         /// <summary>
+        /// Get a property from an object instance and specify the derived type to match
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="fieldName">Field name</param>
+        /// <param name="derivedType">Derived type</param>
+        /// <returns></returns>
+        public static PropertyInfo GetProperty(this object obj, string name, Type derivedType)
+        {
+            var t = obj.GetType();
+            var properties = t.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var val = properties
+                .FirstOrDefault(p => p.Name.Equals(name) && p.PropertyType.Equals(derivedType));
+            if (val == null)
+            {
+                val = properties
+                    .Single(p => p.Name.Equals(name) && p.DeclaringType.Equals(derivedType));
+            }
+            return val;
+        }
+
+        /// <summary>
         /// Get a field from an object instance
         /// </summary>
         /// <param name="obj"></param>

--- a/TypeSupport/TypeSupport/Extensions/TypeExtensions.cs
+++ b/TypeSupport/TypeSupport/Extensions/TypeExtensions.cs
@@ -135,6 +135,19 @@ namespace TypeSupport.Extensions
         }
 
         /// <summary>
+        /// Get an extended property object by name
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="name"></param>
+        /// <param name="declaringType">The declaring type the property belongs to</param>
+        /// <returns></returns>
+        public static ExtendedProperty GetExtendedProperty(this Type type, string name, Type declaringType)
+        {
+            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            return properties.Single(x => x.Name.Equals(name) && x.DeclaringType.Equals(declaringType));
+        }
+
+        /// <summary>
         /// Get an extended field object by name
         /// </summary>
         /// <param name="type"></param>
@@ -143,6 +156,19 @@ namespace TypeSupport.Extensions
         public static ExtendedField GetExtendedField(this Type type, string name)
         {
             return type.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        }
+
+        /// <summary>
+        /// Get an extended field object by name
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="name"></param>
+        /// <param name="declaringType">The delcaring type the field belongs to</param>
+        /// <returns></returns>
+        public static ExtendedField GetExtendedField(this Type type, string name, Type declaringType)
+        {
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            return fields.Single(x => x.Name.Equals(name) && x.DeclaringType.Equals(declaringType));
         }
     }
 }


### PR DESCRIPTION
 AmbiguousMatchException thrown when inherited properties of the same name are searched for
Fixes #17