### PR TITLE
Fix for Explicitly Implemented Interface Declared Generic Property

### DIFF
--- a/TypeSupport/TypeSupport.Tests/ObjectFactoryTests.cs
+++ b/TypeSupport/TypeSupport.Tests/ObjectFactoryTests.cs
@@ -261,5 +261,15 @@ namespace TypeSupport.Tests
             Assert.NotNull(instance);
             Assert.AreEqual(typeof(int), instance.GetType());
         }
+
+        [Test]
+        public void Should_CreateObjectWithExplicitlyImplementedInterfaceDeclaredGenericProperty()
+        {
+            var factory = new ObjectFactory();
+            var instance = factory.CreateEmptyObject(typeof(ObjectWithExplicitlyImplementedInterfaceDeclaredGenericProperty<int>));
+
+            Assert.NotNull(instance);
+            Assert.AreEqual(typeof(int), instance.GetType());
+        }
     }
 }

--- a/TypeSupport/TypeSupport.Tests/ObjectFactoryTests.cs
+++ b/TypeSupport/TypeSupport.Tests/ObjectFactoryTests.cs
@@ -269,7 +269,9 @@ namespace TypeSupport.Tests
             var instance = factory.CreateEmptyObject(typeof(ObjectWithExplicitlyImplementedInterfaceDeclaredGenericProperty<int>));
 
             Assert.NotNull(instance);
-            Assert.AreEqual(typeof(int), instance.GetType());
+            Assert.AreEqual(
+                typeof(ObjectWithExplicitlyImplementedInterfaceDeclaredGenericProperty<int>),
+                instance.GetType());
         }
     }
 }

--- a/TypeSupport/TypeSupport.Tests/TestObjects/ObjectWithExplicitlyImplementedInterfaceDeclaredGenericProperty.cs
+++ b/TypeSupport/TypeSupport.Tests/TestObjects/ObjectWithExplicitlyImplementedInterfaceDeclaredGenericProperty.cs
@@ -1,0 +1,13 @@
+﻿namespace TypeSupport.Tests.TestObjects
+{
+
+    public interface IValue<T>
+    {
+        T Value { get; }
+    }
+
+    public class ObjectWithExplicitlyImplementedInterfaceDeclaredGenericProperty<T> : IValue<T>
+    {
+        T IValue<T>.Value { get; }
+    }
+}

--- a/TypeSupport/TypeSupport/ExtendedField.cs
+++ b/TypeSupport/TypeSupport/ExtendedField.cs
@@ -67,12 +67,14 @@ namespace TypeSupport
         public ExtendedField(FieldInfo fieldInfo)
         {
             _fieldInfo = fieldInfo;
-            if (fieldInfo.Name.Contains("k__BackingField") || fieldInfo.Name.StartsWith("<"))
+            var name = fieldInfo.Name;
+            if (name.Contains("k__BackingField") || name.StartsWith("<"))
             {
                 IsBackingField = true;
-                var i = fieldInfo.Name.IndexOf("<");
-                var end = fieldInfo.Name.IndexOf(">", i + 1);
-                BackedPropertyName = fieldInfo.Name.Substring(i + 1, end - (i + 1));
+                var i = name.IndexOf("<");
+                var end = name.LastIndexOf(">");
+
+                BackedPropertyName = name.Substring(i + 1, end - (i + 1));
                 BackedProperty = ReflectedType.GetExtendedProperty(BackedPropertyName, fieldInfo.DeclaringType);
             }
         }


### PR DESCRIPTION
Added Test case to duplicate the issue.

The mistake was the assumption that there would only be one closing ">" in a type.
Switching to LastIndexOf searches from the end forward and doesn't matter if there are more than one.